### PR TITLE
Add exporter for sym/templates mapping information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,9 @@ dependencies = [
  "constraint_writers",
  "json",
  "program_structure",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]

--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -18,6 +18,8 @@ pub struct ExecutionConfig {
     pub flag_verbose: bool,
     pub inspect_constraints_flag: bool,
     pub sym_flag: bool,
+    pub sym_templates_info_flag: bool,
+    pub templates: String,
     pub r1cs_flag: bool,
     pub json_substitution_flag: bool,
     pub json_constraint_flag: bool,
@@ -49,15 +51,21 @@ pub fn execute_project(
     }
     if config.sym_flag {
         generate_output_sym(&config.sym, exporter.as_ref())?;
+    }
+    if config.sym_templates_info_flag {
         // The templates.json output is only available from the DAG exporter,
-        // which is kept when simplification is disabled (--O0 / flag_f). In the
-        // simplified path the exporter is a ConstraintList, which does not
-        // implement templates(), so we skip it to keep plain --sym runs working.
-        if config.flag_f {
-            // replace the trailing .sym of the output path with .templates.json
-            let templates_file = config.sym.replace(".sym", ".templates.json");
-            generate_templates_output(&templates_file, exporter.as_ref())?;
+        // which is kept when simplification is disabled (--O0 / flag_f). This is
+        // validated up front in input_user, but we guard here as well so the
+        // ConstraintList exporter (which does not implement templates()) is
+        // never asked for it.
+        if !config.flag_f {
+            eprintln!(
+                "{}",
+                Colour::Red.paint("--sym-templates-info can only be used with the O0 optimization level (--O0)")
+            );
+            return Result::Err(());
         }
+        generate_templates_output(&config.templates, exporter.as_ref())?;
     }
     if config.json_constraint_flag {
         generate_json_constraints(&debug, exporter.as_ref())?;

--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -49,6 +49,15 @@ pub fn execute_project(
     }
     if config.sym_flag {
         generate_output_sym(&config.sym, exporter.as_ref())?;
+        // The templates.json output is only available from the DAG exporter,
+        // which is kept when simplification is disabled (--O0 / flag_f). In the
+        // simplified path the exporter is a ConstraintList, which does not
+        // implement templates(), so we skip it to keep plain --sym runs working.
+        if config.flag_f {
+            // replace the trailing .sym of the output path with .templates.json
+            let templates_file = config.sym.replace(".sym", ".templates.json");
+            generate_templates_output(&templates_file, exporter.as_ref())?;
+        }
     }
     if config.json_constraint_flag {
         generate_json_constraints(&debug, exporter.as_ref())?;
@@ -82,6 +91,16 @@ fn generate_json_constraints(
 ) -> Result<(), ()> {
     if let Ok(()) = exporter.json_constraints(&debug) {
         println!("{} {}", Colour::Green.paint("Constraints written in:"), debug.json_constraints);
+        Result::Ok(())
+    } else {
+        eprintln!("{}", Colour::Red.paint("Could not write the output in the given path"));
+        Result::Err(())
+    }
+}
+
+fn generate_templates_output(file: &str, exporter: &dyn ConstraintExporter) -> Result<(), ()> {
+    if let Result::Ok(()) = exporter.templates(file) {
+        println!("{} {}", Colour::Green.paint("Written successfully:"), file);
         Result::Ok(())
     } else {
         eprintln!("{}", Colour::Red.paint("Could not write the output in the given path"));

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -14,6 +14,7 @@ pub struct Input {
     pub out_c_code: PathBuf,
     pub out_c_dat: PathBuf,
     pub out_sym: PathBuf,
+    pub out_templates: PathBuf,
     //pub field: &'static str,
     pub c_flag: bool,
     pub wasm_flag: bool,
@@ -22,6 +23,7 @@ pub struct Input {
     pub sanity_check_style: usize,
     pub r1cs_flag: bool,
     pub sym_flag: bool,
+    pub sym_templates_info_flag: bool,
     pub json_constraint_flag: bool,
     pub json_substitution_flag: bool,
     pub main_inputs_flag: bool,
@@ -69,6 +71,15 @@ impl Input {
         let o_style = input_processing::get_simplification_style(&matches)?;
         let sanity_check_style = input_processing::get_sanity_check_style(&matches)?;
         let link_libraries = input_processing::get_link_libraries(&matches);
+        let sym_templates_info_flag = input_processing::get_sym_templates_info(&matches);
+        if sym_templates_info_flag && o_style != SimplificationStyle::O0 {
+            return Result::Err(eprintln!(
+                "{}",
+                Colour::Red.paint(
+                    "The --sym-templates-info flag can only be used with the O0 optimization level (--O0)"
+                )
+            ));
+        }
         Result::Ok(Input {
             //field: P_BN128,
             input_program: input,
@@ -82,6 +93,7 @@ impl Input {
             out_c_code: Input::build_output(&output_c_path, &file_name, CPP),
             out_c_dat: Input::build_output(&output_c_path, &file_name, DAT),
             out_sym: Input::build_output(&output_path, &file_name, SYM),
+            out_templates: Input::build_output(&output_path, &file_name, "templates.json"),
             out_json_constraints: Input::build_output(
                 &output_path,
                 &format!("{}_constraints", file_name),
@@ -99,6 +111,7 @@ impl Input {
             sanity_check_style: sanity_check_style as usize,
             r1cs_flag: input_processing::get_r1cs(&matches),
             sym_flag: input_processing::get_sym(&matches),
+            sym_templates_info_flag,
             main_inputs_flag: input_processing::get_main_inputs_log(&matches),
             json_constraint_flag: input_processing::get_json_constraints(&matches),
             json_substitution_flag: input_processing::get_json_substitutions(&matches),
@@ -141,6 +154,9 @@ impl Input {
     }
     pub fn sym_file(&self) -> &str {
         self.out_sym.to_str().unwrap()
+    }
+    pub fn templates_file(&self) -> &str {
+        self.out_templates.to_str().unwrap()
     }
     pub fn wat_file(&self) -> &str {
         self.out_wat_code.to_str().unwrap()
@@ -206,6 +222,9 @@ impl Input {
     }
     pub fn sym_flag(&self) -> bool {
         self.sym_flag
+    }
+    pub fn sym_templates_info_flag(&self) -> bool {
+        self.sym_templates_info_flag
     }
     pub fn print_ir_flag(&self) -> bool {
         self.print_ir_flag
@@ -320,6 +339,10 @@ mod input_processing {
 
     pub fn get_sym(matches: &ArgMatches) -> bool {
         matches.is_present("print_sym")
+    }
+
+    pub fn get_sym_templates_info(matches: &ArgMatches) -> bool {
+        matches.is_present("sym_templates_info")
     }
 
     pub fn get_r1cs(matches: &ArgMatches) -> bool {
@@ -481,6 +504,13 @@ mod input_processing {
                     .takes_value(false)
                     .display_order(60)
                     .help("Outputs witness in sym format"),
+            )
+            .arg(
+                Arg::with_name("sym_templates_info")
+                    .long("sym-templates-info")
+                    .takes_value(false)
+                    .display_order(61)
+                    .help("Outputs a <name>.templates.json file mapping each template to its signals (requires --O0)"),
             )
             .arg(
                 Arg::with_name("print_r1cs")

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -49,6 +49,8 @@ fn start() -> Result<(), ()> {
         json_constraint_flag: user_input.json_constraints_flag(),
         json_substitution_flag: user_input.json_substitutions_flag(),
         sym_flag: user_input.sym_flag(),
+        sym_templates_info_flag: user_input.sym_templates_info_flag(),
+        templates: user_input.templates_file().to_string(),
         sym: user_input.sym_file().to_string(),
         r1cs: user_input.r1cs_file().to_string(),
         json_constraints: user_input.json_constraints_file().to_string(),

--- a/constraint_list/src/lib.rs
+++ b/constraint_list/src/lib.rs
@@ -177,6 +177,13 @@ impl ConstraintExporter for ConstraintList {
     fn sym(&self, out: &str) -> Result<(), ()> {
         sym_porting::port_sym(self, out)
     }
+
+    fn templates(&self, _out: &str) -> Result<(), ()> {
+        // The templates.json output is only produced from the DAG exporter,
+        // which is kept when simplification is disabled (--O0). The simplified
+        // ConstraintList exporter is never asked for it (see execution_user).
+        unreachable!("templates output requires the DAG exporter (--O0)")
+    }
 }
 
 impl ConstraintList {

--- a/constraint_writers/src/lib.rs
+++ b/constraint_writers/src/lib.rs
@@ -9,4 +9,5 @@ pub trait ConstraintExporter {
     fn r1cs(&self, out: &str, custom_gates: bool) -> Result<(), ()>;
     fn json_constraints(&self, writer: &debug_writer::DebugWriter) -> Result<(), ()>;
     fn sym(&self, out: &str) -> Result<(), ()>;
+    fn templates(&self, out: &str) -> Result<(), ()>;
 }

--- a/dag/Cargo.toml
+++ b/dag/Cargo.toml
@@ -10,3 +10,6 @@ constraint_writers = { path = "../constraint_writers" }
 circom_algebra = { path = "../circom_algebra" }
 program_structure = { path = "../program_structure" }
 json = "0.12.4"
+serde = "1.0.82"
+serde_derive = "1.0.91"
+serde_json = "1.0.39"

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -3,6 +3,7 @@ mod json_porting;
 mod map_to_constraint_list;
 mod r1cs_porting;
 mod sym_porting;
+mod templates_porting;
 mod witness_producer;
 use circom_algebra::num_bigint::BigInt;
 use constraint_list::ConstraintList;
@@ -313,6 +314,10 @@ impl ConstraintExporter for DAG {
     fn sym(&self, out: &str) -> Result<(), ()> {
         DAG::generate_sym_output(self, out)
     }
+
+    fn templates(&self, out: &str) -> Result<(), ()> {
+        DAG::generate_templates_output(self, out)
+    }
 }
 
 impl DAG {
@@ -484,6 +489,10 @@ impl DAG {
 
     pub fn generate_sym_output(&self, output_file: &str) -> Result<(), ()> {
         sym_porting::write(self, output_file)
+    }
+
+    pub fn generate_templates_output(&self, output_file: &str) -> Result<(), ()> {
+        templates_porting::write(self, output_file)
     }
 
     pub fn generate_json_constraints(&self, debug: &DebugWriter) -> Result<(), ()> {

--- a/dag/src/templates_porting.rs
+++ b/dag/src/templates_porting.rs
@@ -1,0 +1,82 @@
+use super::{Tree, DAG};
+use circom_algebra::num_traits::AsPrimitive;
+use constraint_writers::sym_writer::*;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use serde_derive::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+struct TemplatesStruct {
+    // template id -> (template name, signal name -> (signal id, full signal name))
+    templates: Vec<(String, HashMap<String, (i64, String)>)>,
+}
+
+impl TemplatesStruct {
+    pub fn new() -> TemplatesStruct {
+        TemplatesStruct {
+            templates: Vec::new(),
+        }
+    }
+}
+
+// pub struct TemplateFile {
+//     data : TemplatesStruct,
+// }
+
+// impl TemplateFile {
+//     pub fn new(file: &str) -> Result<TemplateFile, ()> {
+//         let file = File::create(file).map_err(|_err| {})?;
+//         // let writer = BufWriter::new(file);
+//         Result::Ok(TemplateFile { data: TemplatesStruct::new() })
+//     }
+
+//     pub fn write_node(sym: &mut TemplateFile, elem: SymElem) -> Result<(), ()> {
+//         sym.writer.write_all(elem.to_string().as_bytes()).map_err(|_err| {})?;
+//         sym.writer.write_all(b"\n").map_err(|_err| {}) //?;
+//         //sym.writer.flush().map_err(|_err| {})
+//     }
+    
+//     pub fn finish_writing(mut sym: TemplateFile) -> Result<(), ()> {
+// 	    sym.writer.flush().map_err(|_err| {})
+//     }
+
+//     // pub fn close(_sym: TemplateFile) {}
+// }
+
+
+pub fn write(dag: &DAG, file_name: &str) -> Result<(), ()> {
+    let tree = Tree::new(dag);
+    let mut data = TemplatesStruct::new();
+    visit_tree(&tree, &mut data)?;
+
+    let serialized_templates = serde_json::to_string_pretty(&data).unwrap();
+    let mut dot_template = File::create(file_name).map_err(|_err| {})?;
+    dot_template.write_all(serialized_templates.as_bytes()).map_err(|_err| {})?;
+    Ok(())
+}
+
+fn visit_tree(tree: &Tree, dot_template: &mut TemplatesStruct) -> Result<(), ()> {
+    let mut node_info = HashMap::new();
+    let mut template_name = String::new();
+    let node_id : i64 = tree.node_id.as_();
+    for signal in &tree.signals {
+        let name = HashMap::get(&tree.id_to_name, signal).unwrap();
+        let symbol = format!("{}.{}", tree.path, name);
+        // println!("Visiting signal: {} {}", name, tree.path);
+        // let node_id = tree.node_id.as_();
+        let node = tree.dag.nodes.get(tree.node_id).unwrap();
+        template_name = node.template_name.clone();
+        // println!("Visiting node: {} {} {:?}", node_id, node.template_name, node.parameters);
+        node_info.insert(name.clone(), (signal.as_(), symbol));
+    }
+
+    dot_template.templates.push((template_name, node_info));
+
+
+    for edge in Tree::get_edges(tree) {
+        let subtree = Tree::go_to_subtree(tree, edge);
+        visit_tree(&subtree, dot_template)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Add `--sym-templates-info` flag for `templates.json` export

### Summary

Adds a `--sym-templates-info` flag to `circom` that emits a `<name>.templates.json` file mapping each instantiated template to its signals. This complements the existing `--sym` output and the `--callgraph` tooling on this base branch with structured, per-template signal info.

### Output format

```jsonc
{
  "templates": [
    [
      "TemplateName",
      {
        "signalName": [123, "full.path.signalName"]  // signal id, fully-qualified symbol
      }
    ]
    // one entry per template instance
  ]
}
```

### How it works

- New `dag/src/templates_porting.rs` walks the constraint `Tree` and records, per template instance, its name and a map of local signal name → `(id, full symbol)`, serialized with `serde_json`.
- Adds a `templates(out)` method to the `ConstraintExporter` trait, implemented by the `DAG` exporter.
- Wires up the `--sym-templates-info` flag and the derived `<name>.templates.json` output path.

### Requires `--O0`

The template structure is only available from the DAG exporter, which is kept only when simplification is disabled. The flag is validated to require `--O0` (and guarded again at execution time).

```sh
circom circuit.circom --O0 --sym-templates-info   # writes circuit.templates.json
```